### PR TITLE
Update 03-04-net.md

### DIFF
--- a/docs/notes/03-hunting_job/02-interview/03-04-net.md
+++ b/docs/notes/03-hunting_job/02-interview/03-04-net.md
@@ -96,7 +96,7 @@ TCP 的连接的拆除需要发送四个包，因此称为四次挥手(Four-way 
 
 ## 63、2MSL等待状态？
 
-TIME_WAIT状态也成为2MSL等待状态。每个具体TCP实现必须选择一个报文段最大生存时间MSL（Maximum Segment Lifetime），它是任何报文段被丢弃前在网络内的最长时间。这个时间是有限的，因为TCP报文段以IP数据报在网络内传输，而IP数据报则有限制其生存时间的TTL字段。
+TIME_WAIT状态也称为2MSL等待状态。每个具体TCP实现必须选择一个报文段最大生存时间MSL（Maximum Segment Lifetime），它是任何报文段被丢弃前在网络内的最长时间。这个时间是有限的，因为TCP报文段以IP数据报在网络内传输，而IP数据报则有限制其生存时间的TTL字段。
 
 对一个具体实现所给定的MSL值，处理的原则是：当TCP执行一个主动关闭，并发回最后一个ACK，该连接必须在TIME_WAIT状态停留的时间为2倍的MSL。这样可让TCP再次发送最后的ACK以防这个ACK丢失（另一端超时并重发最后的FIN）。
 
@@ -223,7 +223,7 @@ HTTPS 采用混合的加密机制，使用**非对称密钥加密用于传输对
 
 1. Client给出协议版本号、一个客户端生成的随机数（Client random），以及客户端支持的加密方法。
 2. Server确认双方使用的加密方法，并给出数字证书、以及一个服务器生成的随机数（Server random）。
-3. Client确认数字证书有效，然后生成呀一个新的随机数（Premaster secret），并使用数字证书中的公钥，加密这个随机数，发给Server。
+3. Client确认数字证书有效，然后生成一个新的随机数（Premaster secret），并使用数字证书中的公钥，加密这个随机数，发给Server。
 4. Server使用自己的私钥，获取Client发来的随机数（Premaster secret）。
 5. Client和Server根据约定的加密方法，使用前面的三个随机数，生成”对话密钥”（session key），用来加密接下来的整个对话过程。
 


### PR DESCRIPTION
问题63、2MSL等待状态？
开头的第一句话：TIME_WAIT状态也**成为**2MSL等待状态。
似乎是错别字？应该是“称为”？
修改后：TIME_WAIT状态也**称为**2MSL等待状态。
问题73、HTTPS采用的加密方式有哪些？是对称还是非对称。
修改前：Client确认数字证书有效，然后生成**呀**（似乎多了一个呀字？）一个新的随机数（Premaster secret），并使用数字证书中的公钥，加密这个随机数，发给Server。 修改后：Client确认数字证书有效，然后生成（去掉了多的一个“呀”字）一个新的随机数（Premaster secret），并使用数字证书中的公钥，加密这个随机数，发给Server。